### PR TITLE
Email Modifications

### DIFF
--- a/sqlFiles/migrations/2015.02.27.1508.sql
+++ b/sqlFiles/migrations/2015.02.27.1508.sql
@@ -1,0 +1,1 @@
+INSERT INTO `resultMessages` (`name`,`value`) VALUES ('emailNotProvided','Email Address is Required.');

--- a/src/admin/config/resultsMsgs.php
+++ b/src/admin/config/resultsMsgs.php
@@ -30,6 +30,7 @@ function defineFields() {
 	$fields['userOverPolicyBookings']   = getResultMessage('userOverPolicyBookings');
 	$fields['errorInserting']           = getResultMessage('errorInserting');
 	$fields['tooFarInFuture']           = getResultMessage('tooFarInFuture');
+	$fields['emailNotProvided']         = getResultMessage('emailNotProvided');
 	
 	return($fields);
 }

--- a/src/admin/email/index.php
+++ b/src/admin/email/index.php
@@ -114,7 +114,7 @@ templates::display('header');
 			<strong>Email</strong>
 		</td>	
 		<td>
-			{local var="email"}
+			<a href="mailto:{local var="email"}">{local var="email"}</a>
 		</td>
 	</tr>
 </table>

--- a/src/admin/reservationCreate.php
+++ b/src/admin/reservationCreate.php
@@ -132,6 +132,7 @@ $endMinute   = ($reservation->isNew())?"0":date("i",$reservation->reservation['e
 
 // Set some localvars for use in the HTML below. 
 $localvars->set("username",($reservation->isNew())?"":$reservation->reservation['username']);
+$localvars->set("email",($reservation->isNew())?"":$reservation->reservation['email']);
 $localvars->set("groupname",($reservation->isNew())?"":$reservation->reservation['groupname']);
 $localvars->set("comments",($reservation->isNew())?"":$reservation->reservation['comments']);
 $localvars->set("action",($reservation->isNew())?"Add":"Update");
@@ -144,9 +145,12 @@ if (isset($_POST['MYSQL']['createNewFromOld'])) {
 
 	$localvars->set("username", (isset($_POST['HTML']['username']) && !is_empty($_POST['HTML']['username']))?$_POST['HTML']['username']:"");
 	$localvars->set("groupname",(isset($_POST['HTML']['groupname']) && !is_empty($_POST['HTML']['groupname']))?$_POST['HTML']['groupname']:"");
-
+	$localvars->set("email",(isset($_POST['HTML']['notificationEmail']) && !is_empty($_POST['HTML']['notificationEmail']))?$_POST['HTML']['notificationEmail']:"");
 }
 
+if (!$reservation->isNew() && $reservation->hasEmail()) {
+	$localvars->set("emailPatron",sprintf('<a href="email/?id=%s">Email Patron</a>',$reservation->reservation['ID']));
+}
 
 if ($submitError) {
 
@@ -192,7 +196,9 @@ templates::display('header');
 
 		<fieldset>
 			<legend>User Information</legend>
-			<label for="username" class="requiredField">Username:</label> &nbsp; <input type="text" id="username" name="username" value="{local var="username"}"/>
+			<label for="username" class="requiredField">Username:</label> &nbsp; <input type="text" id="username" name="username" value="{local var="username"}" required/>
+			<br />
+			<label for="notificationEmail" class="requiredField">Email:</label> &nbsp; <input type="text" id="notificationEmail" name="notificationEmail" value="{local var="email"}" required/> {local var="emailPatron"}
 			<br />
 			<label for="groupName">Groupname:</label> &nbsp; <input type="text" id="groupname" name="groupname" value="{local var="groupname"}"/>
 		</fieldset>
@@ -320,12 +326,6 @@ templates::display('header');
 		<br />
 		<fieldset>
 			<legend>Administrative Information</legend>
-
-			<?php if (!$reservation->isNew() && $reservation->hasEmail()) { ?>
-
-			<a href="email/?id={local var="reservationID"}">Email Patron</a><br /><br />
-
-			<?php }	?>
 
 			<label for="via">Via:</label>
 			<select name="via" id="via">

--- a/src/includes/class_reservation.php
+++ b/src/includes/class_reservation.php
@@ -103,6 +103,12 @@ class reservation {
 			return FALSE;
 		}
 
+		// check that an email address was submitted
+		if (!isset($_POST['MYSQL']['notificationEmail']) || is_empty($_POST['MYSQL']['notificationEmail'])) {
+			errorHandle::errorMsg(getResultMessage("emailNotProvided"));
+			return FALSE;
+		}
+
 		// convert the start time to unix
 
 		// convert the end time to unix
@@ -592,7 +598,7 @@ class reservation {
 				);
 		}
 		else {
-			$sql        = sprintf("UPDATE `reservations` SET startTime=?, endTime=?, modifiedOn=?, modifiedBy=?, username=?, initials=?, groupname=?, comments=?, createdVia=? WHERE ID=?");
+			$sql        = sprintf("UPDATE `reservations` SET startTime=?, endTime=?, modifiedOn=?, modifiedBy=?, username=?, initials=?, groupname=?, comments=?, createdVia=?, email=? WHERE ID=?");
 			$sqlOptions = array(
 				$sUnix,
 				$eUnix,
@@ -603,6 +609,7 @@ class reservation {
 				$groupname,
 				$comments,
 				$via,
+				(isset($_POST['MYSQL']['notificationEmail']))?$_POST['MYSQL']['notificationEmail']:"",
 				$this->reservation['ID']
 				);
 		}

--- a/src/room.php
+++ b/src/room.php
@@ -305,8 +305,8 @@ templates::display('header');
 		<textarea id="openEventDescription" name="openEventDescription"></textarea>
 	</div>
 	<br /><br />
-	<label name="notificationEmail">Email Address (<strong><em>optional, for email confirmation</em></strong>):</label>
-	<input type="email" name="notificationEmail" id="notificationEmail" placeholder="" />
+	<label name="notificationEmail" class="requiredField" >Email Address:</label>
+	<input type="email" name="notificationEmail" id="notificationEmail" placeholder="" required />
 	<br /><br />
 	
 	<input type="submit" name="createSubmit" value="Reserve this Room" />


### PR DESCRIPTION
Email address is now required when creating a reservation.

Added a result Message (configurable via the admin interface) for when an email address is left blank.

Moved the email patron link to make it more visible.

Added a link to the email page so that you can click on the email and open in your default email app.
